### PR TITLE
disable login workflow and hard-code user/pw

### DIFF
--- a/src/Disco/Disco/Core/Commands.fs
+++ b/src/Disco/Disco/Core/Commands.fs
@@ -30,10 +30,10 @@ type Command =
   | GetServiceInfo
   | MachineStatus
   | MachineConfig
-  | CreateProject of CreateProjectOptions
-  | CloneProject of projectName:Name * uri:Url
-  | PullProject of machineId:string * projectName:Name * uri:Url
-  | LoadProject of projectName:Name * username:UserName * password:Password * site:NameAndId option
-  | GetProjectSites of projectName:Name * username:UserName * password:Password
+  | CreateProject   of CreateProjectOptions
+  | PullProject     of machineId:string * projectName:Name * uri:Url
+  | CloneProject    of projectName:Name * uri:Url
+  | LoadProject     of projectName:Name * site:NameAndId option
+  | GetProjectSites of projectName:Name
 
 type CommandAgent = Command -> Async<Either<DiscoError,string>>

--- a/src/Disco/Disco/Service/CommandActions.fs
+++ b/src/Disco/Disco/Service/CommandActions.fs
@@ -277,13 +277,21 @@ let startAgent (cfg: DiscoMachine) (disco: IDisco) =
           |> Either.map (fun _ -> "Successfully saved project")
         | CloneProject (name, gitUri) -> cloneProject name gitUri
         | PullProject (id, name, gitUri) -> pullProject id name gitUri
-        | LoadProject(projectName, username, password, Some { Id = siteId; Name = name }) ->
-          disco.LoadProject(projectName, username, password, Some (name, siteId))
+        | LoadProject(projectName, Some { Id = siteId; Name = name }) ->
+          disco.LoadProject(
+            projectName,
+            Measure.name Constants.ADMIN_USER_NAME,
+            Measure.password Constants.ADMIN_DEFAULT_PASSWORD,
+            Some (name, siteId))
           |> Either.map (fun _ -> "Loaded project " + unwrap projectName)
-        | LoadProject(projectName, username, password, _) ->
-          disco.LoadProject(projectName, username, password, None)
+        | LoadProject(projectName, _) ->
+          disco.LoadProject(
+            projectName,
+            Measure.name Constants.ADMIN_USER_NAME,
+            Measure.password Constants.ADMIN_DEFAULT_PASSWORD,
+            None)
           |> Either.map (fun _ -> "Loaded project " + unwrap projectName)
-        | GetProjectSites(projectName, _, _) -> getProjectSites cfg projectName
+        | GetProjectSites projectName -> getProjectSites cfg projectName
 
       replyChannel.Reply res
       do! loop()

--- a/src/Disco/Disco/Service/CommandLine.fs
+++ b/src/Disco/Disco/Service/CommandLine.fs
@@ -322,12 +322,10 @@ module CommandLine =
       do!
         match projectDir with
         | Some projectDir ->
-          let name, user, password, site =
+          let name, site =
             name (unwrap projectDir),
-            name "admin",
-            password "Nsynk",
             None
-          Commands.Command.LoadProject(name, user, password, site)
+          Commands.Command.LoadProject(name, site)
           |> CommandActions.postCommand agentRef
           |> Async.RunSynchronously
           |> Either.map ignore

--- a/src/Frontend/src/Frontend/Elmish/Modal.fs
+++ b/src/Frontend/src/Frontend/Elmish/Modal.fs
@@ -80,10 +80,10 @@ module Modal =
     interface IModal with
       member this.SetResult(v) = res <- unbox v
 
-  type ProjectConfig(sites: NameAndId[], info: IProjectInfo) =
+  type ProjectConfig(sites: NameAndId[], name: Name) =
     let mutable res = None
     member __.Sites = sites
-    member __.Info = info
+    member __.Name = name
     member __.Result: NameAndId = res.Value
     interface IModal with
       member this.SetResult(v) = res <- Some(unbox v)

--- a/src/Frontend/src/Frontend/Lib.fs
+++ b/src/Frontend/src/Frontend/Lib.fs
@@ -159,7 +159,7 @@ let addMember(memberIpAddr: string, memberHttpPort: uint16) =
 
     // TODO: Using the admin user for now, should it be the same user as leader A?
     let! loadResult =
-      LoadProject(latestState.Project.Name, name "admin", password "Nsynk", active)
+      LoadProject(latestState.Project.Name, active)
       |> postCommandPrivate memberIpAndPort
 
     printfn "response: %A" loadResult
@@ -231,8 +231,8 @@ let nullify _: 'a = null
 
 // * loadProject
 
-let loadProject(project: Name, username: UserName, pass: Password, site: NameAndId option, ipAndPort: string option): JS.Promise<string option> =
-  LoadProject(project, username, pass, site)
+let loadProject(project: Name, site: NameAndId option, ipAndPort: string option): JS.Promise<string option> =
+  LoadProject(project, site)
   |> postCommandPrivate ipAndPort
   |> Promise.bind (fun res ->
     if res.Ok
@@ -258,8 +258,8 @@ let loadProject(project: Name, username: UserName, pass: Password, site: NameAnd
 
 // * getProjectSites
 
-let getProjectSites(project, username, password) =
-  GetProjectSites(project, username, password) |> postCommand
+let getProjectSites(project) =
+  GetProjectSites(project) |> postCommand
     ofJson<NameAndId[]>
     (fun msg -> Notifications.error msg; [||])
 


### PR DESCRIPTION
This PR temporarily disables the login workflow in the front-end, since the users code paths are not used properly right now. Closes #16 