### PR TITLE
improve error message display on cli

### DIFF
--- a/src/Disco/Disco/Core/Constants.fs
+++ b/src/Disco/Disco/Core/Constants.fs
@@ -250,7 +250,7 @@ module Constants =
     let PROJECT_MISSING_CLUSTER = "Missing active cluster configuration"
 
     [<Literal>]
-    let PROJECT_MISSING_MEMBER = "Missing member"
+    let PROJECT_MISSING_MEMBER = "Missing member active cluster configuration"
 
     [<Literal>]
     let PROJECT_MEMBER_MISMATCH = "is different from Machine"

--- a/src/Disco/Disco/Core/Error.fs
+++ b/src/Disco/Disco/Core/Error.fs
@@ -178,7 +178,7 @@ module Error =
   /// - error: `DiscoError` - error to convert into a human understable message
   ///
   /// Returns: string
-  let inline toMessage (error: DiscoError) = error.ToString()
+  let inline toMessage (error: DiscoError) = error.Message
 
   // ** toExitCode
 


### PR DESCRIPTION
instead of calling `.ToString()` on the error, just display `.Message`

Closes #37 