### PR TITLE
filter VVVV core dlls during copying to zipped dir

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -114,9 +114,11 @@
       <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
         <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
+        <AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
       </PaketReferencesFileLinesInfo>
       <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
         <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
+        <PrivateAssets Condition="%(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'true'">All</PrivateAssets>
       </PackageReference>
     </ItemGroup>
 

--- a/build.fsx
+++ b/build.fsx
@@ -264,9 +264,12 @@ let build config fsproj _ =
 
 let withoutBuildData (path: string) =
   not (path.Contains("node_modules")) &&
+  not (path.Contains("VVVV.Core.dll")) &&
+  not (path.Contains("VVVV.Utils.dll")) &&
+  not (path.Contains("VVVV.UtilsIL.dll")) &&
+  not (path.Contains("System.ComponentModel.Composition.CodePlex.dll")) &&
   not (path.Contains("_temporary_compressed_files"))
 
-// ---------------------------------------------------------------------
 // ACTIONS
 // ---------------------------------------------------------------------
 


### PR DESCRIPTION
This removes the VVVV core and util dll's from the build output by filtering those files. This could also be achieved by setting `copy_local: flase` globally in `paket.dependencies` and then manually adding `copy_local:true` for libraries where they are needed, but would have been a whole lot more work. This fixes #48 