### PR TITLE
reset trigger bools after 10ms in service

### DIFF
--- a/src/Disco/Disco/MockClient/Main.fs
+++ b/src/Disco/Disco/MockClient/Main.fs
@@ -533,7 +533,7 @@ Usage:
               updateSlices client slices
 
             | BoolPin data ->
-              let slices = BoolSlices(data.Id, None, parseBoolValues rest)
+              let slices = BoolSlices(data.Id, None, false, parseBoolValues rest)
               updateSlices client slices
 
             | BytePin data ->

--- a/src/Disco/Disco/Nodes/Nodes/GraphNode.fs
+++ b/src/Disco/Disco/Nodes/Nodes/GraphNode.fs
@@ -574,9 +574,9 @@ module rec Graph =
 
   // ** parsePinValueWith
 
-  let private parsePinValueWith (pid: PinId) (tipe: PinType) (props: Property array) (pin: IPin2) =
+  let private parsePinValueWith (pid: PinId) (tipe: PinType) trig (props: Property array) (pin: IPin2) =
     match tipe with
-    | PinType.Boolean -> BoolSlices(pid, None, parseBoolValues pin)
+    | PinType.Boolean -> BoolSlices(pid, None, trig, parseBoolValues pin)
     | PinType.Number  -> NumberSlices(pid, None, parseDoubleValues pin)
     | PinType.String  -> StringSlices(pid, None, parseStringValues pin)
     | PinType.Color   -> ColorSlices(pid, None, parseColorValues pin)
@@ -647,7 +647,7 @@ module rec Graph =
     let rp    = node.FindPin Settings.ROWS_PIN
     let pp    = node.FindPin Settings.PAGES_PIN
     let tp    = node.FindPin Settings.TAG_PIN
-
+    let trig  = isTrigger node
     let tipe  = parsePinType node |> Either.defaultValue PinType.Number
     let props = parseEnumProperties node
 
@@ -672,7 +672,7 @@ module rec Graph =
       |> state.Events.Enqueue)
 
     let changedHandler = new EventHandler(fun _ _ ->
-      let slices = parsePinValueWith parsed.Id tipe props pin
+      let slices = parsePinValueWith parsed.Id tipe trig props pin
       (parsed.PinGroupId, parsed.Id, slices)
       |> Msg.PinValueChange
       |> state.Events.Enqueue)
@@ -1492,8 +1492,8 @@ module rec Graph =
         then
           let slices =
             match nm.Properties with
-            | Some props -> parsePinValueWith id nm.Type props nm.Pin
-            | _ ->  parsePinValueWith id nm.Type [| |] nm.Pin
+            | Some props -> parsePinValueWith id nm.Type nm.Trigger props nm.Pin
+            | _ ->  parsePinValueWith id nm.Type nm.Trigger Array.empty nm.Pin
           let cmd =
             [ (id, slices) ]
             |> Map.ofList

--- a/src/Disco/Disco/Nodes/Nodes/PinWriteNode.fs
+++ b/src/Disco/Disco/Nodes/Nodes/PinWriteNode.fs
@@ -79,9 +79,14 @@ type PinWriteNode() =
 
             /// process updates to pin slices
             | UpdateSlices map when Map.containsKey mapping.PinId map.Slices ->
-              mapping.Pin.Spread <- map.Slices.[mapping.PinId].ToSpread()
-              if mapping.Trigger then
-                resetEvents.Enqueue(frame, mapping)
+              match map.Slices.[mapping.PinId] with
+              // ignore resets
+              | BoolSlices (_,_,trig,values) when trig && not (Array.contains true values) -> ()
+              | slices ->
+                mapping.Pin.Spread <- map.Slices.[mapping.PinId].ToSpread()
+                if mapping.Trigger then
+                  // schedule frame accurate reset
+                  resetEvents.Enqueue(frame, mapping)
             | _ -> ()
       do processResets()
       do bumpFrame()

--- a/src/Disco/Disco/Tests/Core/ApiTests.fs
+++ b/src/Disco/Disco/Tests/Core/ApiTests.fs
@@ -310,7 +310,7 @@ module ApiTests =
         expect "Server should have one cuelist" 1 len store.State.CueLists
         expect "Client should have one cuelist" 1 len client.State.CueLists
 
-        client.UpdatePin (Pin.setSlice (BoolSlice(index 0, false)) pin)
+        client.UpdatePin (Pin.setSlice (BoolSlice(index 0, false, false)) pin)
 
         do! waitFor "clientUpdate" clientUpdate
 

--- a/src/Disco/Disco/Tests/Core/Disco/EnsureClientUpdateNoLoop.fs
+++ b/src/Disco/Disco/Tests/Core/Disco/EnsureClientUpdateNoLoop.fs
@@ -126,7 +126,7 @@ module EnsureClientUpdateNoLoop =
         do! waitFor "appendDone" appendDone
         do! waitFor "clientAppendDone" clientAppendDone
 
-        let update = BoolSlices(pin.Id, None, [| false |])
+        let update = BoolSlices(pin.Id, None, false, [| false |])
 
         client.UpdateSlices [
           update

--- a/src/Disco/Disco/Tests/Core/Disco/EnsureCueResolver.fs
+++ b/src/Disco/Disco/Tests/Core/Disco/EnsureCueResolver.fs
@@ -134,7 +134,7 @@ module EnsureCueResolver =
         let cue = {
           Id = DiscoId.Create()
           Name = name "hi"
-          Slices = [| BoolSlices(pin.Id, None, [| false |]) |]
+          Slices = [| BoolSlices(pin.Id, None, false, [| false |]) |]
         }
 
         cue

--- a/src/Disco/Disco/Tests/Core/Disco/EnsureMappingResolver.fs
+++ b/src/Disco/Disco/Tests/Core/Disco/EnsureMappingResolver.fs
@@ -96,7 +96,7 @@ module EnsureMappingResolver =
         ///   | |  __/\__ \ |_
         ///   |_|\___||___/\__|
 
-        let slices = BoolSlices(source.Id, None, [| true |])
+        let slices = BoolSlices(source.Id, None, false, [| true |])
 
         [ slices ]
         |> UpdateSlices.ofList

--- a/src/Disco/Disco/Tests/Core/Disco/PinBecomesDirty.fs
+++ b/src/Disco/Disco/Tests/Core/Disco/PinBecomesDirty.fs
@@ -132,7 +132,7 @@ module PinBecomesDirty =
         //    |_| append group and check its marked 'online'
 
         client.UpdateSlices [
-          BoolSlices(toggle.Id, None, [| false |])
+          BoolSlices(toggle.Id, None, false, [| false |])
         ]
 
         do! waitFor "updateDone" updateDone

--- a/src/Disco/Disco/Tests/Core/Generators.fs
+++ b/src/Disco/Disco/Tests/Core/Generators.fs
@@ -682,18 +682,25 @@ module Generators =
     |> Gen.oneof
 
   let sliceGen =
-    [ Gen.map StringSlice (Gen.zip indexGen stringGen)
-      Gen.map NumberSlice (Gen.zip indexGen doubleGen)
-      Gen.map BoolSlice   (Gen.zip indexGen boolGen)
-      Gen.map ByteSlice   (Gen.zip indexGen bytesGen)
-      Gen.map EnumSlice   (Gen.zip indexGen propertyGen)
-      Gen.map ColorSlice  (Gen.zip indexGen colorGen) ]
+    [ Gen.map StringSlice (Gen.zip  indexGen stringGen)
+      Gen.map NumberSlice (Gen.zip  indexGen doubleGen)
+      Gen.map BoolSlice   (Gen.zip3 indexGen boolGen boolGen)
+      Gen.map ByteSlice   (Gen.zip  indexGen bytesGen)
+      Gen.map EnumSlice   (Gen.zip  indexGen propertyGen)
+      Gen.map ColorSlice  (Gen.zip  indexGen colorGen) ]
     |> Gen.oneof
 
   let slicesGen =
+    let boolSlicesGen = gen {
+      let! id = idGen
+      let! mid = maybeGen idGen
+      let! trig = boolGen
+      let! value = boolsGen
+      return id, mid, trig, value
+    }
     [ Gen.map StringSlices (Gen.zip3 idGen (maybeGen idGen) stringsGen)
       Gen.map NumberSlices (Gen.zip3 idGen (maybeGen idGen) doublesGen)
-      Gen.map BoolSlices   (Gen.zip3 idGen (maybeGen idGen) boolsGen)
+      Gen.map BoolSlices   boolSlicesGen
       Gen.map ByteSlices   (Gen.zip3 idGen (maybeGen idGen) (Gen.arrayOfLength 2 bytesGen))
       Gen.map EnumSlices   (Gen.zip3 idGen (maybeGen idGen) (Gen.arrayOfLength 2 propertyGen))
       Gen.map ColorSlices  (Gen.zip3 idGen (maybeGen idGen) (Gen.arrayOfLength 2 colorGen)) ]

--- a/src/Disco/Disco/Tests/Core/SerializationTests.fs
+++ b/src/Disco/Disco/Tests/Core/SerializationTests.fs
@@ -589,7 +589,7 @@ module SerializationTests =
   // /_/   \_\_|_|   |_|\___||___/\__|___/
 
   let serializationTests =
-    testList "Serialization Tests" [
+    ftestList "Serialization Tests" [
       test_binary_pingroup_map
       test_binary_referenced_value
       test_yaml_referenced_value

--- a/src/Disco/Disco/Tests/Core/StoreTests.fs
+++ b/src/Disco/Disco/Tests/Core/StoreTests.fs
@@ -767,18 +767,18 @@ module StoreTests =
         let player = CuePlayer.create "My Player" (Some cueList.Id)
         player |> AddCuePlayer |> store.Dispatch
 
-        [ BoolSlices(player.NextId, None, [| true |]) ]
+        [ BoolSlices(player.NextId, None, false, [| true |]) ]
         |> UpdateSlices.ofList
         |> store.Dispatch
 
-        [ BoolSlices(player.NextId, None, [| true |]) ]
+        [ BoolSlices(player.NextId, None, false, [| true |]) ]
         |> UpdateSlices.ofList
         |> store.Dispatch
 
         let updated = State.cuePlayer player.Id store.State |> Option.get
         expect "Should have advanced one step" (player.Selected + 2<index>) id updated.Selected
 
-        [ BoolSlices(player.PreviousId, None, [| true |]) ]
+        [ BoolSlices(player.PreviousId, None, false, [| true |]) ]
         |> UpdateSlices.ofList
         |> store.Dispatch
 

--- a/src/Disco/Disco/Tests/TestUtilities.fs
+++ b/src/Disco/Disco/Tests/TestUtilities.fs
@@ -127,6 +127,8 @@ module TestData =
     rand.NextBytes(arr)
     arr
 
+  let mkBool() = rand.Next(0,2) > 0
+
   let mkBytes() =
     [| for n in 0 .. rand.Next(2,12) -> mkByte() |]
 
@@ -195,7 +197,7 @@ module TestData =
 
   let mkSlice() =
     match rand.Next(0,6) with
-    | 0 -> BoolSlices(mk(), maybe_mk(), mkBools())
+    | 0 -> BoolSlices(mk(), maybe_mk(), mkBool(), mkBools())
     | 1 -> StringSlices(mk(), maybe_mk(), mkStrings())
     | 2 -> NumberSlices(mk(), maybe_mk(), mkNumbers())
     | 3 -> ByteSlices(mk(), maybe_mk(), mkBytes())

--- a/src/Disco/Projects/MockClient/MockClient.fsproj
+++ b/src/Disco/Projects/MockClient/MockClient.fsproj
@@ -65,7 +65,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Mono.Zeroconf.Providers.Bonjour">
-      <HintPath>..\..\..\Zeroconf\bin\M$(Configuration)\ono.Zeroconf.Providers.Bonjour.dll</HintPath>
+      <HintPath>..\..\..\Zeroconf\bin\$(Configuration)\Mono.Zeroconf.Providers.Bonjour.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/Disco/Schema/Core.fbs
+++ b/src/Disco/Schema/Core.fbs
@@ -235,6 +235,7 @@ table DoubleFB {
 }
 
 table BoolFB {
+     Trigger: bool;
      Value: bool;
 }
 
@@ -325,6 +326,7 @@ table DoublesFB {
 }
 
 table BoolsFB {
+     Trigger: bool;
      Values: [bool];
 }
 

--- a/src/Frontend/src/Core.Frontend/FlatBufferTypes.fs
+++ b/src/Frontend/src/Core.Frontend/FlatBufferTypes.fs
@@ -1047,12 +1047,14 @@ type DoublesFBConstructor =
 let DoublesFB: DoublesFBConstructor = failwith "JS only"
 
 type BoolsFB =
+  abstract Trigger: bool
   abstract ValuesLength: int
   abstract Values: int -> bool
 
 type BoolsFBConstructor =
   abstract StartBoolsFB: builder: FlatBufferBuilder -> unit
   abstract CreateValuesVector: builder: FlatBufferBuilder * bool array -> VectorOffset
+  abstract AddTrigger: builder: FlatBufferBuilder * trig:bool -> unit
   abstract AddValues: builder: FlatBufferBuilder * VectorOffset -> unit
   abstract EndBoolsFB: builder: FlatBufferBuilder -> Offset<BoolsFB>
   abstract GetRootAsBoolsFB: bytes: ByteBuffer -> BoolsFB
@@ -1956,11 +1958,13 @@ let ClockFB: ClockFBConstructor = failwith "JS only"
 // |____/ \___/ \___/|_|_|   |____/
 
 type BoolFB =
+  abstract Trigger: bool
   abstract Value: bool
 
 type BoolFBConstructor =
   abstract prototype: BoolFB with get, set
   abstract StartBoolFB: builder: FlatBufferBuilder -> unit
+  abstract AddTrigger: builder: FlatBufferBuilder * trigger:bool -> unit
   abstract AddValue: builder: FlatBufferBuilder * value: bool -> unit
   abstract EndBoolFB: builder: FlatBufferBuilder -> Offset<BoolFB>
   abstract GetRootAsBoolFB: bytes: ByteBuffer -> BoolFB

--- a/src/Frontend/src/Frontend/Elmish/Cues/CueView.fs
+++ b/src/Frontend/src/Frontend/Elmish/Cues/CueView.fs
@@ -57,8 +57,8 @@ let private updateSlicesValue (index: int) (value: obj) slices: Slices =
     StringSlices(id, client, castValue<string> arr index value)
   | NumberSlices(id, client, arr) ->
     NumberSlices(id, client, castValue<double> arr index value)
-  | BoolSlices  (id, client, arr) ->
-    BoolSlices  (id, client, castValue<bool> arr index value)
+  | BoolSlices  (id, client, trig, arr) ->
+    BoolSlices  (id, client, trig, castValue<bool> arr index value)
   | ByteSlices  (id, client, arr) ->
     ByteSlices  (id, client, castValue<byte[]> arr index value)
   | EnumSlices  (id, client, arr) ->

--- a/src/Frontend/src/Frontend/Elmish/Inspectors/PinInspector.fs
+++ b/src/Frontend/src/Frontend/Elmish/Inspectors/PinInspector.fs
@@ -33,12 +33,12 @@ module PinInspector =
   let private renderSlices (tag: string) (slices: Slices) =
     let slices: ReactElement array =
       slices.Map (function
-      | StringSlice(idx, value) -> renderValue (string idx) (string value)
-      | NumberSlice(idx, value) -> renderValue (string idx) (string value)
-      | BoolSlice(idx, value)   -> renderValue (string idx) (string value)
-      | ByteSlice(idx, value)   -> renderValue (string idx) (string value)
-      | EnumSlice(idx, value)   -> renderValue (string idx) (string value)
-      | ColorSlice(idx, value)  -> renderValue (string idx) (string value))
+      | StringSlice(idx, value)  -> renderValue (string idx) (string value)
+      | NumberSlice(idx, value)  -> renderValue (string idx) (string value)
+      | BoolSlice(idx, _, value) -> renderValue (string idx) (string value)
+      | ByteSlice(idx, value)    -> renderValue (string idx) (string value)
+      | EnumSlice(idx, value)    -> renderValue (string idx) (string value)
+      | ColorSlice(idx, value)   -> renderValue (string idx) (string value))
     slices
     |> List.ofArray
     |> Common.tableRow tag [ "Index"; "Value" ]

--- a/src/Frontend/src/Frontend/Lib.fs
+++ b/src/Frontend/src/Frontend/Lib.fs
@@ -320,7 +320,7 @@ let updatePinValue(pin: Pin, index: int, value: obj) =
       | :? string as v -> box(v.ToLower() = "true")
       | v -> v
     tryUpdateArray index value pin.Values
-    |> Option.map (fun values -> BoolSlices(pin.Id, client, values))
+    |> Option.map (fun values -> BoolSlices(pin.Id, client, pin.IsTrigger, values))
   | EnumPin pin ->
     let prop =
       Array.tryPick

--- a/src/Frontend/src/Tests.Frontend/SerializationTests.fs
+++ b/src/Frontend/src/Tests.Frontend/SerializationTests.fs
@@ -85,7 +85,7 @@ module SerializationTests =
       [| "hello" |]
 
   let mkSlices() =
-    BoolSlices(DiscoId.Create(), None, [| true; false; true; true; false |])
+    BoolSlices(DiscoId.Create(), None, false, [| true; false; true; true; false |])
 
   let mkSlicesMap() =
     let slices = mkSlices ()
@@ -388,10 +388,10 @@ module SerializationTests =
       finish ()
 
     test "Validate Slice Serialization" <| fun finish ->
-      [| BoolSlice  (0<index>, true    )
-      ; StringSlice (0<index>, "hello" )
-      ; NumberSlice (0<index>, 1234.0  )
-      ; ByteSlice   (0<index>, mkBytes ())
+      [| BoolSlice  (0<index>, false, true)
+      ; StringSlice (0<index>, "hello")
+      ; NumberSlice (0<index>, 1234.0)
+      ; ByteSlice   (0<index>, mkBytes())
       ; EnumSlice   (0<index>, { Key = "one"; Value = "two" })
       ; ColorSlice  (0<index>, RGBA { Red = 255uy; Blue = 255uy; Green = 255uy; Alpha = 255uy })
       ; ColorSlice  (0<index>, HSLA { Hue = 255uy; Saturation = 255uy; Lightness = 255uy; Alpha = 255uy })
@@ -400,7 +400,7 @@ module SerializationTests =
       finish()
 
     test "Validate Slices Serialization" <| fun finish ->
-      [| BoolSlices    (mk(), None, [| true    |])
+      [| BoolSlices    (mk(), None, true, [| true    |])
       ; StringSlices   (mk(), None, [| "hello" |])
       ; NumberSlices   (mk(), None, [| 1234.0  |])
       ; ByteSlices     (mk(), None, [| mkBytes () |])


### PR DESCRIPTION
`BoolPin` values that have `IsTrigger` set to `true` now automatically get reset to 0 after roughly 10ms. These automatic reset events are ignored by the `PinWrite` node in VVVV, where the update is automatically to occur in the next frame. This fixes #49 