### PR TITLE
Automated command line setup and CLI improvements 

### DIFF
--- a/src/Disco/Disco/Core/Network.fs
+++ b/src/Disco/Disco/Core/Network.fs
@@ -106,6 +106,16 @@ module Network =
         else lst)
       []
 
+  // ** isOnline
+
+  let isOnline (iface: NetworkInterface) =
+    match iface.Type, iface.Status with
+    | NetworkInterfaceType.Loopback,  _
+    | NetworkInterfaceType.Unknown _, _
+    | _, NetworkInterfaceStatus.Down
+    | _, NetworkInterfaceStatus.Unknown _ -> false
+    | _ -> true
+
   // ** checkIpAddress
 
   let private checkIpAddress (ip: IpAddress) (ifaces: NetworkInterface list) =

--- a/src/Disco/Disco/Service/CommandLine.fs
+++ b/src/Disco/Disco/Service/CommandLine.fs
@@ -84,9 +84,10 @@ module CommandLine =
 
   type CLIArguments =
     | [<Mandatory;MainCommand;CliPosition(CliPosition.First)>] Cmd of SubCommand
-    | [<EqualsAssignment>] Project        of string
-    | [<EqualsAssignment>] Machine        of string
-    | [<EqualsAssignment>] Frontend       of string
+    | [<EqualsAssignment>]     Project  of string
+    | [<EqualsAssignment>]     Machine  of string
+    | [<EqualsAssignment>]     Frontend of string
+    | [<AltCommandLine("-y")>] Yes
 
     interface IArgParserTemplate with
       member self.Usage =
@@ -94,6 +95,7 @@ module CommandLine =
           | Project _   -> "Name of project directory in the workspace"
           | Machine _   -> "Path to the machine config file"
           | Frontend _  -> "Path to the frontend files"
+          | Yes         -> "Don't prompt and choose defaults during setup command"
           | Cmd     _   -> "Main Command: either one of setup, start, or help."
 
   let parser = ArgumentParser.Create<CLIArguments>()


### PR DESCRIPTION
* added a `--yes/-y` flag to choose default values and first public network non-loopback interface
* in interactive mode, prompt for workspace first, then use workspace as base path for asset and log directory

