### PR TITLE
do not treat updates to CuePlayer virutal pins as triggers

### DIFF
--- a/src/Disco/Disco/Core/StateMachine.fs
+++ b/src/Disco/Disco/Core/StateMachine.fs
@@ -3985,18 +3985,18 @@ module CuePlayerExtensions =
 
     static member next (cue:Cue) (player:CuePlayer) =
       CommandBatch.ofList [
-        UpdateSlices.ofList [ BoolSlices(player.NextId, None, true, [| true |]) ]
+        UpdateSlices.ofList [ BoolSlices(player.NextId, None, false, [| true |]) ]
         CallCue cue
       ]
 
     static member previous (cue:Cue) (player:CuePlayer) =
       CommandBatch.ofList [
-        UpdateSlices.ofList [ BoolSlices(player.PreviousId, None, true, [| true |]) ]
+        UpdateSlices.ofList [ BoolSlices(player.PreviousId, None, false, [| true |]) ]
         CallCue cue
       ]
 
     static member call (cue:Cue) (player:CuePlayer) =
       CommandBatch.ofList [
-        UpdateSlices.ofList [ BoolSlices(player.CallId, None, true, [| true |]) ]
+        UpdateSlices.ofList [ BoolSlices(player.CallId, None, false, [| true |]) ]
         CallCue cue
       ]

--- a/src/Frontend/css/main.scss
+++ b/src/Frontend/css/main.scss
@@ -204,7 +204,19 @@ html, body {
 
     // Push other elements to the sides
     .disco-title-bar {
-        flex: 1;
+      flex: 1;
+
+      .disco-icon {
+        width: 10px;
+        min-width: 10px;
+        cursor: initial;
+        height: 10px;
+        padding: 5px;
+        margin-right: 5px;
+        border: 1px solid #aaa;
+        border-radius: 3px;
+        background: white;
+      }
     }
 
     //Icon Sizes
@@ -253,7 +265,7 @@ html, body {
 }
 
 .warning {
-  background-color: $warning;
+  background-color: $warning !important;
 }
 
 .disco-inspector {

--- a/src/Frontend/src/Frontend/Elmish/Cues/CuePlayerView.fs
+++ b/src/Frontend/src/Frontend/Elmish/Cues/CuePlayerView.fs
@@ -315,10 +315,10 @@ type Component(props) =
       /// | |   / _ \ / __| |/ /
       /// | |__| (_) | (__|   <
       /// |_____\___/ \___|_|\_\
-      button [
+      span [
         classList [
           "warning",locked
-          "disco-button", true
+          "disco-icon", true
         ]
         Disabled true
       ] [


### PR DESCRIPTION
When automatic reset of trigger pins was introduced, updates to the cue players virtual pins were treated as triggers and automatic reset events scheduled, which cause the cueplayer count to be bumped by 2 per step. This fixes #72 